### PR TITLE
add funcs to allow caller to supply their own chan

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -72,51 +72,12 @@ func (s *Stream) Measurements(p Params) (<-chan *Measurement, error) {
 //
 // "buffering": none - Unimplemented
 func (s *Stream) MeasurementLatest(p Params) (<-chan *measurement.Result, error) {
-    subscribe := make(map[string]interface{})
-
-    subscribe["stream_type"] = "result"
-
-    for k, v := range p {
-        switch k {
-        case "msm":
-            v, ok := v.(int)
-            if !ok {
-                return nil, fmt.Errorf("Invalid %s parameter, must be int", k)
-            }
-            subscribe["msm"] = v
-        case "type":
-            v, ok := v.(string)
-            if !ok {
-                return nil, fmt.Errorf("Invalid %s parameter, must be string", k)
-            }
-            subscribe["type"] = v
-        case "sourceAddress":
-            fallthrough
-        case "sourcePrefix":
-            fallthrough
-        case "destinationAddress":
-            fallthrough
-        case "destinationPrefix":
-            fallthrough
-        case "passThroughHost":
-            fallthrough
-        case "passThroughPrefix":
-            fallthrough
-        case "sendBacklog":
-            fallthrough
-        case "buffering":
-            return nil, fmt.Errorf("Unimplemented parameter %s", k)
-        default:
-            return nil, fmt.Errorf("Invalid parameter %s", k)
-        }
+    c, subscribe, err := subscribeAndDial(p)
+    if err != nil {
+        return nil, err
     }
 
     ch := make(chan *measurement.Result)
-
-    c, err := gosocketio.Dial(StreamUrl, transport.GetDefaultWebsocketTransport())
-    if err != nil {
-        return nil, fmt.Errorf("gosocketio.Dial(%s): %s", StreamUrl, err.Error())
-    }
 
     err = c.On("atlas_error", func(h *gosocketio.Channel, args interface{}) {
         r := &measurement.Result{ParseError: fmt.Errorf("atlas_error: %v", args)}
@@ -128,7 +89,7 @@ func (s *Stream) MeasurementLatest(p Params) (<-chan *measurement.Result, error)
     }
 
     err = c.On("atlas_result", func(h *gosocketio.Channel, r measurement.Result) {
-    	trySend(ch, &r)
+        trySend(ch, &r)
     })
     if err != nil {
         return nil, fmt.Errorf("c.On(atlas_result): %s", err.Error())
@@ -158,21 +119,138 @@ func (s *Stream) MeasurementLatest(p Params) (<-chan *measurement.Result, error)
     return ch, nil
 }
 
+// MeasurementLatestWithChan streams the latest measurement results, as described
+// by the Params, and sends them to the supplied channel. The channel supplied should
+// not be closed, but should be reused between connections of the same measurement.
+//
+// Params available are:
+//
+// "msm": int - The measurement id to get results from.
+//
+// "type": string - The measurement result type to stream.
+//
+// "sourceAddress": none - Unimplemented
+//
+// "sourcePrefix": none - Unimplemented
+//
+// "destinationAddress": none - Unimplemented
+//
+// "destinationPrefix": none - Unimplemented
+//
+// "passThroughHost": none - Unimplemented
+//
+// "passThroughPrefix": none - Unimplemented
+//
+// "sendBacklog": none - Unimplemented
+//
+// "buffering": none - Unimplemented
+func (s *Stream) MeasurementLatestWithChan(p Params, ch chan *measurement.Result) error {
+    c, subscribe, err := subscribeAndDial(p)
+    if err != nil {
+        return err
+    }
+
+    err = c.On("atlas_error", func(h *gosocketio.Channel, args interface{}) {
+        r := &measurement.Result{ParseError: fmt.Errorf("atlas_error: %v", args)}
+        ch <- r
+        c.Close()
+    })
+    if err != nil {
+        return fmt.Errorf("c.On(atlas_error): %s", err.Error())
+    }
+
+    err = c.On("atlas_result", func(h *gosocketio.Channel, r measurement.Result) {
+        ch <- &r
+    })
+    if err != nil {
+        return fmt.Errorf("c.On(atlas_result): %s", err.Error())
+    }
+
+    err = c.On(gosocketio.OnConnection, func(h *gosocketio.Channel) {
+        err := h.Emit("atlas_subscribe", subscribe)
+        if err != nil {
+            r := &measurement.Result{ParseError: fmt.Errorf("h.Emit(atlas_subscribe): %s", err.Error())}
+            ch <- r
+            c.Close()
+        }
+    })
+    if err != nil {
+        return fmt.Errorf("c.On(connect): %s", err.Error())
+    }
+
+    return nil
+}
+
+// trySend is a hack to avoid panicking when sending to a closed channel
 func trySend(ch chan *measurement.Result, r *measurement.Result) {
     defer func() {
-    	recover()
+        recover()
     }()
     func() {
         ch <- r
     }()
 }
 
-// Since Stream streams the latest results (more or less, backlog sending
-// is available), MeasurementResults will just call MeasurementLatest.
+// MeasurementResults will just call MeasurementLatest since Stream streams the latest results
+// (more or less, backlog sending is available)
 func (s *Stream) MeasurementResults(p Params) (<-chan *measurement.Result, error) {
     return s.MeasurementLatest(p)
 }
 
+// MeasurementResultsWithChan will just call MeasurementLatestWithChan since Stream streams the latest results
+// (more or less, backlog sending is available). The supplied channel should be reused and not closed
+func (s *Stream) MeasurementResultsWithChan(p Params, ch chan *measurement.Result) error {
+    return s.MeasurementLatestWithChan(p, ch)
+}
+
 func (s *Stream) Probes(p Params) (<-chan *request.Probe, error) {
     return nil, fmt.Errorf("Unimplemented")
+}
+
+func subscribeAndDial(p Params) (*gosocketio.Client, map[string]interface{}, error) {
+    subscribe := make(map[string]interface{})
+
+    subscribe["stream_type"] = "result"
+
+    for k, v := range p {
+        switch k {
+        case "msm":
+            v, ok := v.(int)
+            if !ok {
+                return nil, subscribe, fmt.Errorf("Invalid %s parameter, must be int", k)
+            }
+            subscribe["msm"] = v
+        case "type":
+            v, ok := v.(string)
+            if !ok {
+                return nil, subscribe, fmt.Errorf("Invalid %s parameter, must be string", k)
+            }
+            subscribe["type"] = v
+        case "sourceAddress":
+            fallthrough
+        case "sourcePrefix":
+            fallthrough
+        case "destinationAddress":
+            fallthrough
+        case "destinationPrefix":
+            fallthrough
+        case "passThroughHost":
+            fallthrough
+        case "passThroughPrefix":
+            fallthrough
+        case "sendBacklog":
+            fallthrough
+        case "buffering":
+            return nil, subscribe, fmt.Errorf("Unimplemented parameter %s", k)
+        default:
+            return nil, subscribe, fmt.Errorf("Invalid parameter %s", k)
+        }
+    }
+
+    c, err := gosocketio.Dial(StreamUrl, transport.GetDefaultWebsocketTransport())
+    if err != nil {
+        return nil, subscribe, fmt.Errorf("gosocketio.Dial(%s): %s", StreamUrl, err.Error())
+    }
+
+    return c, subscribe, nil
 }

--- a/stream.go
+++ b/stream.go
@@ -145,7 +145,7 @@ func (s *Stream) MeasurementLatest(p Params) (<-chan *measurement.Result, error)
 // "sendBacklog": none - Unimplemented
 //
 // "buffering": none - Unimplemented
-func (s *Stream) MeasurementLatestWithChan(p Params, ch chan *measurement.Result) (<-chan struct{}, error) {
+func (s *Stream) MeasurementLatestWithChan(p Params, ch chan<- *measurement.Result) (<-chan struct{}, error) {
     c, subscribe, err := subscribeAndDial(p)
     if err != nil {
         return nil, err
@@ -194,7 +194,7 @@ func (s *Stream) MeasurementLatestWithChan(p Params, ch chan *measurement.Result
 }
 
 // trySend is a hack to avoid panicking when sending to a closed channel
-func trySend(ch chan *measurement.Result, r *measurement.Result) {
+func trySend(ch chan<- *measurement.Result, r *measurement.Result) {
     defer func() {
         recover()
     }()
@@ -212,7 +212,7 @@ func (s *Stream) MeasurementResults(p Params) (<-chan *measurement.Result, error
 // MeasurementResultsWithChan will just call MeasurementLatestWithChan since Stream streams the latest results
 // (more or less, backlog sending is available). The supplied channel should be reused and not closed. A channel is
 // returned that will receive an empty struct and be closed when the connection is closed.
-func (s *Stream) MeasurementResultsWithChan(p Params, ch chan *measurement.Result) (<-chan struct{}, error) {
+func (s *Stream) MeasurementResultsWithChan(p Params, ch chan<- *measurement.Result) (<-chan struct{}, error) {
     return s.MeasurementLatestWithChan(p, ch)
 }
 


### PR DESCRIPTION
Add functions to allow the caller to supply their own chan instead of returning a channel and trying to manage its lifecycle. This avoid having to use trySend, and allows the library's user to manage the lifecycle of the channel, or even to use a buffered chan.

`MeasurementLatest` is unchanged, other than removing the code used to generate the subscribe map and gosocketio client into a new function, `subscribeAndDial`. New funcs have been added `MeasurementLatestWithChan` and `MeasurementResultsWithChan` that take the channel as an argument (instead of creating it and returning the channel). The major difference is, `MeasurementLatestWithChan` does not use `trySend` and has no handler for onDisconnection, since there is no lifecycle management for it to do with a persistent channel.

Since the channel returned by `MeasurementLatest` was used to signal when the connection had been closed (in order to trigger a new connection), the new `MeasurementLatestWithChan` returns a channel which is only used to communicate that the connection has closed. That is accomplished by sending an empty struct, `StreamClosedEvent`, to the channel and closing it.

For example, with the existing `MeasurementLatest` func, it was used like this:
```
func Listen(p Params) {
    stream := NewStream()
    // loop forever
    for {
        // create the connection and subscribe to our measurements
        resultsChan, _ := stream.MeasurementLatest(p)

        // process results in a loop
        for {
            r, ok := <- resultsChan
            if !ok {
                // channel is closed, indicating the stream has been closed, break the loop
                break
            }
            
            // do something with the result
            AddResult(r)
        }
    }
}
```

With the new `MeasurementLatestWithChan` func, the same behavior would be accomplished like this:
```
func Listen(p Params) {
    stream := NewStream()
    resultsChan := make(chan *measurement.Result)

    // start processing results in a goroutine
    go func() {
        // process results in a loop
        for {
            r, ok := <- resultsChan
            if !ok {
                // channel is closed
                break
            }

            // do something with the result
            AddResult(r)
        }
    }()


    // loop forever
    for {
        // create the connection and subscribe to our measurements
        doneChan, _ := stream.MeasurementLatestWithChan(p, resultsChan)

        // block until the doneChan receives a StreamClosedEvent struct, indicating the connection has been closed
        <- doneChan
    }
}
```
